### PR TITLE
Session attribute is currently mapped to `attributes.string` as a `ma…

### DIFF
--- a/skillserver/echo.go
+++ b/skillserver/echo.go
@@ -166,10 +166,8 @@ type EchoSession struct {
 	Application struct {
 		ApplicationID string `json:"applicationId"`
 	} `json:"application"`
-	Attributes struct {
-		String map[string]interface{} `json:"string"`
-	} `json:"attributes"`
-	User struct {
+	Attributes map[string]interface{} `json:"attributes"`
+	User       struct {
 		UserID      string `json:"userId"`
 		AccessToken string `json:"accessToken,omitempty"`
 	} `json:"user"`


### PR DESCRIPTION
…p[string]interface{}`

Based on the documentation [here](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/alexa-skills-kit-interface-reference#request-format), the attributes is a map.